### PR TITLE
Replace deprecated getinfo rpc command

### DIFF
--- a/collect/corerpc/rpc.go
+++ b/collect/corerpc/rpc.go
@@ -93,9 +93,9 @@ func (r *client) newRequest(method string, params interface{}) *request {
 	}
 }
 
-func (c *client) getInfo() (map[string]interface{}, error) {
+func (c *client) getNetworkInfo() (map[string]interface{}, error) {
 	var info map[string]interface{}
-	req := c.newRequest("getinfo", nil)
+	req := c.newRequest("getnetworkinfo", nil)
 	res, err := c.send(req)
 	if err != nil {
 		return nil, err
@@ -155,7 +155,7 @@ func (c *client) pollMempool() (height int64, entries map[string]*MempoolEntry, 
 }
 
 func (c *client) getRelayFee() (sim.FeeRate, error) {
-	info, err := c.getInfo()
+	info, err := c.getNetworkInfo()
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
getinfo is deprecated, I believe since v15, You have now more specific commands to get the info needed, and getnetworkinfo is the one needed here.